### PR TITLE
Test travis install from CRAN than github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ cache: packages
 sudo: required
 dist: trusty
 
-r_github_packages:
-    - jimhester/covr
+r_packages:
+    - covr
 
 before_install:
   - sudo add-apt-repository ppa:ubuntugis/ppa --yes


### PR DESCRIPTION
I have had this issue of Travis trying to install packages from github, it is actually safer to install from CRAN and `covr` is on CRAN.